### PR TITLE
Java language support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM vmware/photon2:20180302
+
+RUN tdnf install -y openjdk8-1.8.0.152-1.ph2 apache-maven-3.5.0-5.ph2
+
+ENV PATH /var/opt/apache-maven/bin:$PATH
+
+ARG IMAGE_TEMPLATE=/image-template
+ARG FUNCTION_TEMPLATE=/function-template
+
+LABEL io.dispatchframework.imageTemplate="${IMAGE_TEMPLATE}" \
+      io.dispatchframework.functionTemplate="${FUNCTION_TEMPLATE}"
+
+COPY image-template ${IMAGE_TEMPLATE}/
+COPY function-template ${FUNCTION_TEMPLATE}/
+
+ENV PORT=8080
+EXPOSE ${PORT}
+
+COPY function-server /function-server/
+
+WORKDIR /function-server
+RUN mvn dependency:copy-dependencies -DoutputDirectory=target/lib -DincludeScope=runtime
+
+CMD java -cp target/classes:target/lib/* io.dispatchframework.javabaseimage.Server $(cat /tmp/package) $(cat /tmp/class)

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e -x
+
+cd $(dirname $0)
+
+docker build -t vmware/dispatch-java8-base:0.0.1-dev1 .

--- a/function-server/pom.xml
+++ b/function-server/pom.xml
@@ -1,0 +1,59 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.dispatchframework.javabaseimage</groupId>
+    <artifactId>function-server</artifactId>
+    <version>1.0.0</version>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.surefire.version>2.21.0</maven.surefire.version>
+
+        <undertow.version>2.0.3.Final</undertow.version>
+        <gson.version>2.8.2</gson.version>
+
+        <junit.jupiter.api.version>5.2.0-M1</junit.jupiter.api.version>
+        <junit.jupiter.engine.version>5.2.0-M1</junit.jupiter.engine.version>
+        <junit.platform.version>1.2.0-M1</junit.platform.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-surefire-provider</artifactId>
+                        <version>${junit.platform.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>${junit.jupiter.engine.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-core</artifactId>
+            <version>${undertow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.api.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/function-server/src/main/java/io/dispatchframework/javabaseimage/Context.java
+++ b/function-server/src/main/java/io/dispatchframework/javabaseimage/Context.java
@@ -1,0 +1,19 @@
+package io.dispatchframework.javabaseimage;
+
+public class Context {
+    private Exception error;
+    private String[] logs;
+
+    public Context(Exception error, String[] logs) {
+        this.error = error;
+        this.logs = logs;
+    }
+
+    public Exception getError() {
+        return error;
+    }
+
+    public String[] getLogs() {
+        return logs;
+    }
+}

--- a/function-server/src/main/java/io/dispatchframework/javabaseimage/Response.java
+++ b/function-server/src/main/java/io/dispatchframework/javabaseimage/Response.java
@@ -1,0 +1,19 @@
+package io.dispatchframework.javabaseimage;
+
+public class Response {
+    private Context context;
+    private Object payload;
+
+    public Response(Context context, Object payload) {
+        this.context = context;
+        this.payload = payload;
+    }
+
+    public Context getContext() {
+        return context;
+    }
+
+    public Object getPayload() {
+        return payload;
+    }
+}

--- a/function-server/src/main/java/io/dispatchframework/javabaseimage/Server.java
+++ b/function-server/src/main/java/io/dispatchframework/javabaseimage/Server.java
@@ -1,0 +1,144 @@
+package io.dispatchframework.javabaseimage;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.function.BiFunction;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import io.undertow.Handlers;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.Undertow;
+import io.undertow.util.Headers;
+
+public class Server {
+    private static final Gson gson = new GsonBuilder().serializeNulls().create();
+
+    public static void main(String[] args) throws Exception {
+        Undertow.builder()
+                .addHttpListener(8080, "0.0.0.0")
+                .setHandler(Handlers.path()
+                        .addPrefixPath("/", new ExecFunction(args[0], args[1]))
+                        .addExactPath("/healthz", new Healthz()))
+                .build()
+                .start();
+    }
+
+    private static void receiverErrorCallback(HttpServerExchange exchange, IOException ex) {
+        // Closing a StringWriter has no effect
+        StringWriter sw = new StringWriter();
+        try (PrintWriter pw = new PrintWriter(sw)) {
+            ex.printStackTrace(pw);
+
+            String[] stderrLogs = sw.toString().split("\\r?\\n");
+            Response response = new Response(new Context(ex, stderrLogs), null);
+
+            String jsonResponse = gson.toJson(response);
+            exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
+            exchange.getResponseSender().send(jsonResponse);
+        }
+    }
+
+    public static class ExecFunction implements HttpHandler {
+        final Type[] biFunctionTypes;
+        final BiFunction f;
+
+        public ExecFunction(String packageName, String className) throws ClassNotFoundException, InstantiationException, IllegalAccessException {
+            Class<?> functionClass = Class.forName(packageName + "." + className);
+            Type[] biFunctionTypes = getBiFunctionTypes(functionClass);
+            if (biFunctionTypes == null || biFunctionTypes.length != 3) {
+                throw new IllegalArgumentException(String.format("%s.%s does not implement the BiFunction interface", packageName, className));
+            }
+            this.biFunctionTypes = biFunctionTypes;
+            this.f = (BiFunction) functionClass.newInstance();
+        }
+
+        public Type[] getBiFunctionTypes(Class<?> functionClass) {
+            Type[] genericInterfaces = functionClass.getGenericInterfaces();
+            Type[] genericTypes = null;
+
+            for (Type genericInterface : genericInterfaces) {
+                if (genericInterface instanceof ParameterizedType) {
+                    ParameterizedType parameterizedType = (ParameterizedType) genericInterface;
+                    if (parameterizedType.getRawType().equals(BiFunction.class)) {
+                        genericTypes = parameterizedType.getActualTypeArguments();
+                        break;
+                    }
+                }
+            }
+
+            return genericTypes;
+        }
+
+        public Object applyFunction(String message) {
+            JsonObject rootObj = new JsonParser().parse(message).getAsJsonObject();
+            JsonElement context = rootObj.get("context");
+            JsonElement payload = rootObj.get("payload");
+
+            return f.apply(gson.fromJson(context, biFunctionTypes[0]), gson.fromJson(payload, biFunctionTypes[1]));
+        }
+
+        @Override
+        public void handleRequest(final HttpServerExchange exchange) {
+            exchange.getRequestReceiver().receiveFullString((httpServerExchange, message) -> {
+                Object r = null;
+                Exception err = null;
+
+                // Closing a ByteArrayOutputStream has no effect
+                ByteArrayOutputStream baosStderr = new ByteArrayOutputStream();
+                ByteArrayOutputStream baosStdout = new ByteArrayOutputStream();
+
+                PrintStream oldStderr = System.err;
+                PrintStream oldStdout = System.out;
+
+                try (PrintStream stderr = new PrintStream(baosStderr);
+                     PrintStream stdout = new PrintStream(baosStdout)) {
+                    try {
+                        System.setErr(stderr);
+                        System.setOut(stdout);
+
+                        r = applyFunction(message);
+                    } catch (Exception ex) {
+                        ex.printStackTrace();
+                        err = ex;
+                    } finally {
+                        System.err.flush();
+                        System.setErr(oldStderr);
+
+                        System.out.flush();
+                        System.setOut(oldStdout);
+
+                        //TODO add support for stdout - https://github.com/vmware/dispatch/issues/355
+                        String[] stderrLogs = baosStderr.toString().length() > 0 ? baosStderr.toString().split("\\r?\\n") : new String[0];
+                        Response response = new Response(new Context(err, stderrLogs), r);
+
+                        String jsonResponse = gson.toJson(response);
+                        httpServerExchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
+                        httpServerExchange.getResponseSender().send(jsonResponse);
+                    }
+                }
+            }, Server::receiverErrorCallback);
+        }
+    }
+
+    public static class Healthz implements HttpHandler {
+        @Override
+        public void handleRequest(final HttpServerExchange exchange) {
+            exchange.getRequestReceiver().receiveFullString((httpServerExchange, message) -> {
+                String jsonResponse = "{}";
+                httpServerExchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
+                httpServerExchange.getResponseSender().send(jsonResponse);
+            }, Server::receiverErrorCallback);
+        }
+    }
+}

--- a/function-server/src/test/java/io/dispatchframework/javabaseimage/BadHandler.java
+++ b/function-server/src/test/java/io/dispatchframework/javabaseimage/BadHandler.java
@@ -1,0 +1,11 @@
+package io.dispatchframework.javabaseimage;
+
+import java.io.Serializable;
+import java.util.function.BiPredicate;
+
+public class BadHandler implements Serializable, BiPredicate<String, String> {
+    @Override
+    public boolean test(String s1, String s2) {
+        return true;
+    }
+}

--- a/function-server/src/test/java/io/dispatchframework/javabaseimage/GoodHandler.java
+++ b/function-server/src/test/java/io/dispatchframework/javabaseimage/GoodHandler.java
@@ -1,0 +1,21 @@
+package io.dispatchframework.javabaseimage;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+
+public class GoodHandler implements Serializable, BiFunction<Map<String, Object>, List<String>, Set<Integer>>, BiPredicate<String, String> {
+    @Override
+    public Set<Integer> apply(Map<String, Object> context, List<String> payload)  {
+        return new HashSet<>();
+    }
+
+    @Override
+    public boolean test(String s1, String s2) {
+        return true;
+    }
+}

--- a/function-server/src/test/java/io/dispatchframework/javabaseimage/Hello.java
+++ b/function-server/src/test/java/io/dispatchframework/javabaseimage/Hello.java
@@ -1,0 +1,18 @@
+package io.dispatchframework.javabaseimage;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+
+public class Hello implements BiFunction<Map<String, Object>, Map<String, Object>, String> {
+    @Override
+    public String apply(Map<String, Object> context, Map<String, Object> payload) {
+        if (payload == null) {
+            return "Hello, Someone from Somewhere";
+        }
+
+        final Object name = payload.getOrDefault("name", "Someone");
+        final Object place = payload.getOrDefault("place", "Somewhere");
+
+        return String.format("Hello, %s from %s", name, place);
+    }
+}

--- a/function-server/src/test/java/io/dispatchframework/javabaseimage/ServerTest.java
+++ b/function-server/src/test/java/io/dispatchframework/javabaseimage/ServerTest.java
@@ -1,0 +1,64 @@
+package io.dispatchframework.javabaseimage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
+
+import org.junit.jupiter.api.Test;
+
+public class ServerTest {
+    private static final String packageName = "io.dispatchframework.javabaseimage";
+
+    @Test
+    public void getBiFunctionTypes_WithInterface() throws Exception {
+        Server.ExecFunction goodHandler = new Server.ExecFunction(packageName, "GoodHandler");
+        assertEquals(3, goodHandler.biFunctionTypes.length);
+        assertEquals("java.util.Map<java.lang.String, java.lang.Object>", goodHandler.biFunctionTypes[0].getTypeName());
+        assertEquals("java.util.List<java.lang.String>", goodHandler.biFunctionTypes[1].getTypeName());
+        assertEquals("java.util.Set<java.lang.Integer>", goodHandler.biFunctionTypes[2].getTypeName());
+    }
+
+    @Test
+    public void getBiFunctionTypes_WithoutInterface() {
+        assertThrows(IllegalArgumentException.class, () -> new Server.ExecFunction(packageName, "BadHandler"));
+    }
+
+    @Test
+    public void applyFunction_Valid() throws Exception {
+        Server.ExecFunction hello = new Server.ExecFunction(packageName, "Hello");
+        String message = "{\"context\": null, \"payload\": {\"name\": \"Jon\", \"place\": \"Winterfell\"}}";
+        Object r = hello.applyFunction(message);
+
+        assertTrue(r instanceof String);
+        assertEquals("Hello, Jon from Winterfell", r);
+    }
+
+    @Test
+    public void applyFunction_Empty() throws Exception {
+        Server.ExecFunction hello = new Server.ExecFunction(packageName, "Hello");
+        String message = "{}";
+        Object r = hello.applyFunction(message);
+
+        assertTrue(r instanceof String);
+        assertEquals("Hello, Someone from Somewhere", r);
+    }
+
+    @Test
+    public void applyFunction_InvalidType() throws Exception {
+        Server.ExecFunction hello = new Server.ExecFunction(packageName, "Hello");
+        String message = "{\"context\": null, \"payload\": \"invalid\"}";
+
+        assertThrows(JsonSyntaxException.class, () -> hello.applyFunction(message));
+    }
+
+    @Test
+    public void applyFunction_InvalidJson() throws Exception {
+        Server.ExecFunction hello = new Server.ExecFunction(packageName, "Hello");
+        String message = "{";
+
+        assertThrows(JsonParseException.class, () -> hello.applyFunction(message));
+    }
+}

--- a/function-template/Dockerfile
+++ b/function-template/Dockerfile
@@ -1,0 +1,20 @@
+ARG IMAGE
+FROM ${IMAGE}
+
+ARG FUNCTION_SRC=function.txt
+
+COPY ${FUNCTION_SRC} .
+
+# Package name
+RUN while read -r _ a _; do echo "$a" ; done <<< $(cat ${FUNCTION_SRC} | grep "^[ $(printf '\t')]*package" | head -1) | sed s'/;*$//' > /tmp/package
+
+# Class name
+RUN while read -r _ _ a _; do echo "$a" ; done <<< $(cat ${FUNCTION_SRC} | sed -e "s/static//" | grep "^[ $(printf '\t')]*public[ $(printf '\t')]*class" | head -1) > /tmp/class
+
+# Copy source file
+RUN mkdir -p src/main/java/$(cat /tmp/package | sed 's:\.:\/:g')
+RUN mv ${FUNCTION_SRC} src/main/java/$(cat /tmp/package | sed 's:\.:\/:g')/$(cat /tmp/class).java
+
+# Compile source files
+RUN mkdir -p target/classes
+RUN javac -d "target/classes" -cp "target/lib/*" src/main/java/io/dispatchframework/javabaseimage/* src/main/java/$(cat /tmp/package | sed 's:\.:\/:g')/$(cat /tmp/class).java

--- a/image-template/Dockerfile
+++ b/image-template/Dockerfile
@@ -1,0 +1,13 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG SYSTEM_PACKAGES_FILE=system-packages.txt
+COPY ${SYSTEM_PACKAGES_FILE} .
+
+RUN packages=$(cat ${SYSTEM_PACKAGES_FILE} | sed 's/ /-/' | uniq | paste -d' ' -); \
+    [ -n "${packages}" ] && tdnf install -y ${packages} || :
+
+ARG PACKAGES_FILE=packages.txt
+COPY ${PACKAGES_FILE} pom2.xml
+
+RUN pj=$(cat pom2.xml); [ -n "${pj}" ] && mvn -f pom2.xml dependency:copy-dependencies -DoutputDirectory=target/lib || :


### PR DESCRIPTION
Fixes https://github.com/vmware/dispatch/issues/359

* Users can define a java function by implementing a class using the BiFunction interface and overriding the apply method
* Runtime dependencies can be specified using a maven pom file
* Accepts a single java file containing the class with the BiFunction interface

Note:
1) There are several edge cases where the package name and class won't be correctly parsed out of a valid java file
    * If there is a comment block specified like so
    ```
    /*
    package com.github.bar;
    */

    package com.github.foo;

    public class Hello ...
    ```
    One fix would be to remove comment blocks from the file before parsing but with a simple tool like sed it would not be possible to handle all possible edge cases (i.e. deeply nested multi-line comments or strings containing block comments). Would likely need an implementation of the java parser in order to do so.

    * If the class is specified like so
    ```
    class Test {} public class Hello implements BiFunction<String, String, String> {
    ```
    Or
    ```
    ;;; ; ;;;;; ;  ; public class Hello implements BiFunction<String, String, String> {
    ```
    the class will not be parsed correctly.

2) There is a possible conflict of dependencies if the user provides a pom file for the function containing a different version of gson or undertow.
