### PR TITLE
Fix empty-pom.xml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ LABEL io.dispatchframework.imageTemplate="${IMAGE_TEMPLATE}" \
 COPY image-template ${IMAGE_TEMPLATE}/
 COPY function-template ${FUNCTION_TEMPLATE}/
 
+RUN cp ${IMAGE_TEMPLATE}/empty-pom.xml /root
+
 COPY function-server /function-server/
 WORKDIR /function-server
 RUN mvn install && cd cp-gen && mvn dependency:build-classpath -Dmdep.outputFile=../cp.txt

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # java-base-image
 Java language support for Dispatch
 
-Latest image [on Docker Hub](https://hub.docker.com/r/dispatchframework/java-base/): `dispatchframework/java-base:0.0.6`
+Latest image [on Docker Hub](https://hub.docker.com/r/dispatchframework/java-base/): `dispatchframework/java-base:0.0.7`
 
 ## Usage
 
@@ -11,7 +11,7 @@ You need a recent version of Dispatch [installed in your Kubernetes cluster, Dis
 
 To add the base-image to Dispatch:
 ```bash
-$ dispatch create base-image java-base dispatchframework/java-base:0.0.6
+$ dispatch create base-image java-base dispatchframework/java-base:0.0.7
 ```
 
 Make sure the base-image status is `READY` (it normally goes from `INITIALIZED` to `READY`):

--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,4 @@ set -e -x
 
 cd $(dirname $0)
 
-docker build -t dispatchframework/java-base:0.0.6 .
+docker build -t dispatchframework/java-base:0.0.7 .


### PR DESCRIPTION
`empty-pom.xml` doesn't exist in the `/root` directory so the following command in the `image-template` fails
```
pj=$(cat pom.xml); ([ -n "${pj}" ] || cp empty-pom.xml pom.xml) && mvn dependency:go-offline && cp pom.xml ${WORKDIR} || :
```
