### PR TITLE
Support single files for Java with or without the handler arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ EXPOSE ${PORT}
 WORKDIR ${WORKDIR}
 
 
-CMD java -cp target/classes:$(<./cp.txt):$(</function-server/cp.txt) io.dispatchframework.javabaseimage.Entrypoint "${HANDLER}"
+CMD java -cp target/classes:$(<./cp.txt):$(</function-server/cp.txt) io.dispatchframework.javabaseimage.Entrypoint $(cat /tmp/handler)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # java-base-image
 Java language support for Dispatch
 
-Latest image [on Docker Hub](https://hub.docker.com/r/dispatchframework/java-base/): `dispatchframework/java-base:0.0.8`
+Latest image [on Docker Hub](https://hub.docker.com/r/dispatchframework/java-base/): `dispatchframework/java-base:0.0.9`
 
 ## Usage
 
@@ -11,7 +11,7 @@ You need a recent version of Dispatch [installed in your Kubernetes cluster, Dis
 
 To add the base-image to Dispatch:
 ```bash
-$ dispatch create base-image java-base dispatchframework/java-base:0.0.8
+$ dispatch create base-image java-base dispatchframework/java-base:0.0.9
 ```
 
 Make sure the base-image status is `READY` (it normally goes from `INITIALIZED` to `READY`):

--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,4 @@ set -e -x
 
 cd $(dirname $0)
 
-docker build -t dispatchframework/java-base:0.0.8 .
+docker build -t dispatchframework/java-base:0.0.9 .

--- a/function-template/Dockerfile
+++ b/function-template/Dockerfile
@@ -4,19 +4,36 @@ FROM ${IMAGE}
 ARG HANDLER
 ENV HANDLER=$HANDLER
 
-RUN ([ -n "${HANDLER}" ] || (echo "HANDLER is required for Java" >&2 && exit 1))
-
 WORKDIR ${WORKDIR}
 
 COPY . .
 
 RUN mvn compile -Dmaven.test.skip=true -Dproject.build.sourceEncoding=UTF-8 -Dmaven.compiler.source=10 -Dmaven.compiler.target=10 dependency:build-classpath -Dmdep.outputFile=./cp.txt
 
+# Create handler file if passed in otherwise extract handler info
+RUN echo -n ${HANDLER} > /tmp/handler
+RUN if ([ -z "${HANDLER}" ] && [ $(ls *.java | wc -l) -eq "1" ]); then \
+    javac -cp .:$(<./cp.txt) -d . $(ls *.java) && \
+    dir=$(ls -d */) && \
+    package=$(find ${dir} -type d | tail -n 1 | sed 's:\/:\.:g') && \
+    class=$(ls *.java) && \
+    class="${class%.*}" && \
+    mkdir -p target/classes && \
+    mv ${dir} target/classes && \
+    echo -n "${package}.${class}" > /tmp/handler; fi
+
+# If single file and handler arg is passed in
+RUN if ([ -n "${HANDLER}" ] && [ $(ls *.java | wc -l) -eq "1" ]); then \
+    javac -cp .:$(<./cp.txt) "${HANDLER##*.}".java && \
+    package=$(echo -n "${HANDLER%.*}" | sed 's:\.:\/:g') && \
+    mkdir -p target/classes/${package} && \
+    mv *.class target/classes/${package}; fi
+
 # Validate function file and given handler
 WORKDIR /validator
 
 RUN mvn install dependency:build-classpath -Dmdep.outputFile=./cp.txt && \
-    java -cp target/classes:${WORKDIR}/target/classes:$(<./cp.txt):$(<${WORKDIR}/cp.txt) io.dispatchframework.javabaseimage.Validator "${HANDLER}" || \
+    java -cp target/classes:${WORKDIR}/target/classes:$(<./cp.txt):$(<${WORKDIR}/cp.txt) io.dispatchframework.javabaseimage.Validator $(cat /tmp/handler) || \
     (echo "Invalid function file or handler" >&2 && exit 1)
 
 WORKDIR ${WORKDIR}


### PR DESCRIPTION
Add single file support with or without the handler arg.

* If handler arg is passed in, the file is compiled and directory structure is created
* If no handler arg is passed in, the file is compiled and the handler info is extracted from compilation